### PR TITLE
Fixing the version number

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - PlayerKit (0.1.0)
+  - PlayerKit (1.0.0)
 
 DEPENDENCIES:
   - PlayerKit (from `../`)
 
 EXTERNAL SOURCES:
   PlayerKit:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  PlayerKit: 4702100274e44e115c28419d8c21c22f13052856
+  PlayerKit: 72b199ef98f44e6cce579b335669aa6d9c86d5c7
 
 PODFILE CHECKSUM: 071d8819500a822237123321021901352f4d91a4
 

--- a/PlayerKit.podspec
+++ b/PlayerKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PlayerKit'
-  s.version          = '0.1.0'
+  s.version          = '1.0.0'
   s.summary          = 'A modular video player system.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
#### Ticket

N/A

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Set version number to 1.0.0

#### Implementation Summary

- PlayerKit.podspec - Updated version number to 1.0.0 

#### How to Test

N/A