### PR TITLE
Add TextTrackMetadata and TextTrackCapable protocols to Player.swift

### DIFF
--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -119,6 +119,24 @@ public enum PlayerError: Int
     case fill
 }
 
+/// The metadata that should be attached to any type of text track
+@objc public protocol TextTrackMetadata
+{
+    var displayName: String { get }
+    var locale: Locale? { get }
+    var describesMusicAndSound: Bool { get }
+    
+    @objc(displayNameWithLocale:) func displayName(with locale: Locale) -> String
+}
+
+/// A player that conforms to the TextTrackCapable protocol is capable of advertising and displaying text tracks.
+@objc public protocol TextTrackCapable
+{
+    func availableTextTracks() -> [TextTrackMetadata]
+    func fetchAvailableTextTracks(completion: @escaping ([TextTrackMetadata]) -> Void)
+    func select(_ textTrack: TextTrackMetadata?)
+}
+
 #if os(iOS)
 /// A player that adopts the ProvidesView protocol is capable of Picture in Picture playback.
 @objc public protocol PictureInPictureCapable

--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -119,7 +119,7 @@ public enum PlayerError: Int
     case fill
 }
 
-/// The metadata that should be attached to any type of text track
+/// The metadata that should be attached to any type of text track.
 @objc public protocol TextTrackMetadata
 {
     var displayName: String { get }


### PR DESCRIPTION
#### Ticket

[VIM-6347](https://vimean.atlassian.net/browse/VIM-6347)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Adds new protocol definitions which allow `Player`s to advertise that they support text tracks, and provide custom objects which contain certain metadata expected of a text track.

#### Implementation Summary

- Introduces the `TextTrackMetadata` protocol which expects that texts tracks will have a name to display, an associated locale for the language/region corresponding to the text track, and a flag indicating whether the track describes music and sound, or just transcribes dialogue.
- Introduces the `TextTrackCapable` protocol, for which conforming objects must offer a way to retrieve the available text tracks (synchronously and asynchronously) and then select a particular track fo display.

#### How to Test

- No testing necessary.
