### PR TITLE
VIM-6353: Make RegularPlayer conform to `TextTrackCapable`

### DIFF
--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -451,13 +451,12 @@ extension RegularPlayer: TextTrackCapable
         }
         else
         {
-            for option in group.options
+            let optionPredicate: (AVMediaSelectionOption) -> Bool = { option in
+                return option.locale == track.locale && (option.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility) == track.describesMusicAndSound)
+            }
+            if let option = group.options.first(where: optionPredicate)
             {
-                if option.locale == track.locale && (option.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility) == track.describesMusicAndSound)
-                {
-                    self.player.currentItem?.select(option, in: group)
-                    break
-                }
+                self.player.currentItem?.select(option, in: group)
             }
         }
     }

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -54,61 +54,6 @@ extension AVMediaSelectionOption: TextTrackMetadata
         self.player.replaceCurrentItem(with: playerItem)
     }
     
-    // MARK: TextTrackCapable
-    
-    public typealias TextTrackType = AVMediaSelectionOption
-    
-    public func availableTextTracks() -> [TextTrackMetadata]
-    {
-        guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
-        {
-            return []
-        }
-        return group.options
-    }
-    
-    public func fetchAvailableTextTracks(completion: @escaping ([TextTrackMetadata]) -> Void)
-    {
-        self.player.currentItem?.asset.loadValuesAsynchronously(forKeys: [#keyPath(AVAsset.availableMediaCharacteristicsWithMediaSelectionOptions)]) { [weak self] in
-            guard let strongSelf = self, let group = strongSelf.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
-            {
-                completion([])
-                return
-            }
-            completion(group.options)
-        }
-    }
-    
-    public func select(_ textTrack: TextTrackMetadata?)
-    {
-        guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
-        {
-            return
-        }
-        
-        guard let track = textTrack else
-        {
-            self.player.currentItem?.select(nil, in: group)
-            return
-        }
-        
-        if let option = track as? AVMediaSelectionOption
-        {
-            self.player.currentItem?.select(option, in: group)
-        }
-        else
-        {
-            for option in group.options
-            {
-                if option.locale == track.locale && (option.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility) == track.describesMusicAndSound)
-                {
-                    self.player.currentItem?.select(option, in: group)
-                    break
-                }
-            }
-        }
-    }
-    
     // MARK: ProvidesView
     
     private class RegularPlayerView: UIView
@@ -460,6 +405,60 @@ extension RegularPlayer: FillModeCapable
             }
 
             (self.view.layer as! AVPlayerLayer).videoGravity = gravity
+        }
+    }
+}
+
+extension RegularPlayer: TextTrackCapable
+{
+    public func availableTextTracks() -> [TextTrackMetadata]
+    {
+        guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
+        {
+            return []
+        }
+        return group.options
+    }
+    
+    public func fetchAvailableTextTracks(completion: @escaping ([TextTrackMetadata]) -> Void)
+    {
+        self.player.currentItem?.asset.loadValuesAsynchronously(forKeys: [#keyPath(AVAsset.availableMediaCharacteristicsWithMediaSelectionOptions)]) { [weak self] in
+            guard let strongSelf = self, let group = strongSelf.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
+            {
+                completion([])
+                return
+            }
+            completion(group.options)
+        }
+    }
+    
+    public func select(_ textTrack: TextTrackMetadata?)
+    {
+        guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
+        {
+            return
+        }
+        
+        guard let track = textTrack else
+        {
+            self.player.currentItem?.select(nil, in: group)
+            return
+        }
+        
+        if let option = track as? AVMediaSelectionOption
+        {
+            self.player.currentItem?.select(option, in: group)
+        }
+        else
+        {
+            for option in group.options
+            {
+                if option.locale == track.locale && (option.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility) == track.describesMusicAndSound)
+                {
+                    self.player.currentItem?.select(option, in: group)
+                    break
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Ticket

[VIM-6353](https://vimean.atlassian.net/browse/VIM-6353)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- We want our `RegularPlayer` to advertise that it is able to display text tracks, so we need to add the required methods.

#### Implementation Summary

- Add an extension so that `AVMediaSelectionOption` conforms to `TextTrackMetadata`. This is the object that `AVFoundation` uses to represent a teach track that is available for display. We provide forward the synchronous and asynchronous method calls to their equivalents on `AVAsset` (if present), and use the media selection API to select the provided text track. 

- If the `TextTrackMetadata` object that we receive in `select(_:)` is not an `AVMediaSelectionOption`, then we simply look for a track that has the same locale and accessibility status and select that if available.

#### Reviewer Tips

#### How to Test

- Not much to test here... if the track show up in `group.options` then we should be able to select the option if it is provided back to us. 
