### PR TITLE
VIM-6350: Turn on/off CC when user taps appropriate item in list

### DIFF
--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -132,6 +132,8 @@ public enum PlayerError: Int
 /// A player that conforms to the TextTrackCapable protocol is capable of advertising and displaying text tracks.
 @objc public protocol TextTrackCapable
 {
+    var selectedTrack: TextTrackMetadata? { get }
+    
     func availableTextTracks() -> [TextTrackMetadata]
     func fetchAvailableTextTracks(completion: @escaping ([TextTrackMetadata]) -> Void)
     func select(_ textTrack: TextTrackMetadata?)

--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -129,6 +129,11 @@ public enum PlayerError: Int
     @objc(displayNameWithLocale:) func displayName(with locale: Locale) -> String
 }
 
+public func ==(lhs: TextTrackMetadata, rhs: TextTrackMetadata) -> Bool
+{
+    return (lhs.locale == rhs.locale && lhs.isSDHTrack == rhs.isSDHTrack)
+}
+
 /// A player that conforms to the TextTrackCapable protocol is capable of advertising and displaying text tracks.
 @objc public protocol TextTrackCapable
 {
@@ -137,14 +142,6 @@ public enum PlayerError: Int
     
     func fetchTextTracks(completion: @escaping ([TextTrackMetadata], TextTrackMetadata?) -> Void)
     func select(_ textTrack: TextTrackMetadata?)
-}
-
-extension TextTrackMetadata
-{
-    public static func ==(lhs: TextTrackMetadata, rhs: TextTrackMetadata) -> Bool
-    {
-        return (lhs.locale == rhs.locale && lhs.isSDHTrack == rhs.isSDHTrack)
-    }
 }
 
 #if os(iOS)

--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -124,6 +124,7 @@ public enum PlayerError: Int
 {
     var displayName: String { get }
     var locale: Locale? { get }
+    // Indicates that the text track represents subtitles for the def and hard of hearing (SDH).
     var isSDHTrack: Bool { get }
     
     @objc(displayNameWithLocale:) func displayName(with locale: Locale) -> String

--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -129,9 +129,12 @@ public enum PlayerError: Int
     @objc(displayNameWithLocale:) func displayName(with locale: Locale) -> String
 }
 
-public func ==(lhs: TextTrackMetadata, rhs: TextTrackMetadata) -> Bool
+extension TextTrackMetadata
 {
-    return (lhs.locale == rhs.locale && lhs.isSDHTrack == rhs.isSDHTrack)
+    public func matches(_ other: TextTrackMetadata) -> Bool
+    {
+        return (self.locale == other.locale && self.isSDHTrack == other.isSDHTrack)
+    }
 }
 
 /// A player that conforms to the TextTrackCapable protocol is capable of advertising and displaying text tracks.

--- a/PlayerKit/Classes/Player.swift
+++ b/PlayerKit/Classes/Player.swift
@@ -124,7 +124,7 @@ public enum PlayerError: Int
 {
     var displayName: String { get }
     var locale: Locale? { get }
-    var describesMusicAndSound: Bool { get }
+    var isSDHTrack: Bool { get }
     
     @objc(displayNameWithLocale:) func displayName(with locale: Locale) -> String
 }
@@ -132,11 +132,19 @@ public enum PlayerError: Int
 /// A player that conforms to the TextTrackCapable protocol is capable of advertising and displaying text tracks.
 @objc public protocol TextTrackCapable
 {
-    var selectedTrack: TextTrackMetadata? { get }
+    var selectedTextTrack: TextTrackMetadata? { get }
+    var availableTextTracks: [TextTrackMetadata] { get }
     
-    func availableTextTracks() -> [TextTrackMetadata]
-    func fetchAvailableTextTracks(completion: @escaping ([TextTrackMetadata]) -> Void)
+    func fetchTextTracks(completion: @escaping ([TextTrackMetadata], TextTrackMetadata?) -> Void)
     func select(_ textTrack: TextTrackMetadata?)
+}
+
+extension TextTrackMetadata
+{
+    public static func ==(lhs: TextTrackMetadata, rhs: TextTrackMetadata) -> Bool
+    {
+        return (lhs.locale == rhs.locale && lhs.isSDHTrack == rhs.isSDHTrack)
+    }
 }
 
 #if os(iOS)

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -469,16 +469,9 @@ extension RegularPlayer: TextTrackCapable
             return
         }
         
-        var options = group.options
-        if let locale = track.locale
-        {
-            options = AVMediaSelectionGroup.mediaSelectionOptions(from: options, with: locale)
-        }
-        if track.isSDHTrack
-        {
-            options = AVMediaSelectionGroup.mediaSelectionOptions(from: options, withMediaCharacteristics: [AVMediaCharacteristic.describesMusicAndSoundForAccessibility.rawValue, AVMediaCharacteristic.transcribesSpokenDialogForAccessibility.rawValue])
-        }
-        
-        self.player.currentItem?.select(options.first, in: group)
+        let option = group.options.first(where: { option in
+            track.matches(option)
+        })
+        self.player.currentItem?.select(option, in: group)
     }
 }

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -418,9 +418,12 @@ extension RegularPlayer: TextTrackCapable
             return nil
         }
         
-        if #available(iOS 9.0, *) {
+        if #available(iOS 9.0, *)
+        {
             return self.player.currentItem?.currentMediaSelection.selectedMediaOption(in: group)
-        } else {
+        }
+        else
+        {
             return self.player.currentItem?.selectedMediaOption(in: group)
         }
     }
@@ -442,9 +445,12 @@ extension RegularPlayer: TextTrackCapable
                 completion([], nil)
                 return
             }
-            if #available(iOS 9.0, *) {
+            if #available(iOS 9.0, *)
+            {
                 completion(group.options, strongSelf.player.currentItem?.currentMediaSelection.selectedMediaOption(in: group))
-            } else {
+            }
+            else
+            {
                 completion(group.options, strongSelf.player.currentItem?.selectedMediaOption(in: group))
             }
         }

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -418,7 +418,11 @@ extension RegularPlayer: TextTrackCapable
             return nil
         }
         
-        return self.player.currentItem?.selectedMediaOption(in: group)
+        if #available(iOS 9.0, *) {
+            return self.player.currentItem?.currentMediaSelection.selectedMediaOption(in: group)
+        } else {
+            return self.player.currentItem?.selectedMediaOption(in: group)
+        }
     }
     
     public func availableTextTracks() -> [TextTrackMetadata]

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -411,6 +411,16 @@ extension RegularPlayer: FillModeCapable
 
 extension RegularPlayer: TextTrackCapable
 {
+    public var selectedTrack: TextTrackMetadata?
+    {
+        guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
+        {
+            return nil
+        }
+        
+        return self.player.currentItem?.selectedMediaOption(in: group)
+    }
+    
     public func availableTextTracks() -> [TextTrackMetadata]
     {
         guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -13,9 +13,9 @@ import AVKit
 
 extension AVMediaSelectionOption: TextTrackMetadata
 {
-    public var describesMusicAndSound: Bool
+    public var isSDHTrack: Bool
     {
-        return self.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility)
+        return self.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility) && self.hasMediaCharacteristic(.transcribesSpokenDialogForAccessibility)
     }
 }
 
@@ -411,7 +411,7 @@ extension RegularPlayer: FillModeCapable
 
 extension RegularPlayer: TextTrackCapable
 {
-    public var selectedTrack: TextTrackMetadata?
+    public var selectedTextTrack: TextTrackMetadata?
     {
         guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
         {
@@ -425,7 +425,7 @@ extension RegularPlayer: TextTrackCapable
         }
     }
     
-    public func availableTextTracks() -> [TextTrackMetadata]
+    public var availableTextTracks: [TextTrackMetadata]
     {
         guard let group = self.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
         {
@@ -434,15 +434,19 @@ extension RegularPlayer: TextTrackCapable
         return group.options
     }
     
-    public func fetchAvailableTextTracks(completion: @escaping ([TextTrackMetadata]) -> Void)
+    public func fetchTextTracks(completion: @escaping ([TextTrackMetadata], TextTrackMetadata?) -> Void)
     {
         self.player.currentItem?.asset.loadValuesAsynchronously(forKeys: [#keyPath(AVAsset.availableMediaCharacteristicsWithMediaSelectionOptions)]) { [weak self] in
             guard let strongSelf = self, let group = strongSelf.player.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else
             {
-                completion([])
+                completion([], nil)
                 return
             }
-            completion(group.options)
+            if #available(iOS 9.0, *) {
+                completion(group.options, strongSelf.player.currentItem?.currentMediaSelection.selectedMediaOption(in: group))
+            } else {
+                completion(group.options, strongSelf.player.currentItem?.selectedMediaOption(in: group))
+            }
         }
     }
     
@@ -459,19 +463,16 @@ extension RegularPlayer: TextTrackCapable
             return
         }
         
-        if let option = track as? AVMediaSelectionOption
+        var options = group.options
+        if let locale = track.locale
         {
-            self.player.currentItem?.select(option, in: group)
+            options = AVMediaSelectionGroup.mediaSelectionOptions(from: options, with: locale)
         }
-        else
+        if track.isSDHTrack
         {
-            let optionPredicate: (AVMediaSelectionOption) -> Bool = { option in
-                return option.locale == track.locale && (option.hasMediaCharacteristic(.describesMusicAndSoundForAccessibility) == track.describesMusicAndSound)
-            }
-            if let option = group.options.first(where: optionPredicate)
-            {
-                self.player.currentItem?.select(option, in: group)
-            }
+            options = AVMediaSelectionGroup.mediaSelectionOptions(from: options, withMediaCharacteristics: [AVMediaCharacteristic.describesMusicAndSoundForAccessibility.rawValue, AVMediaCharacteristic.transcribesSpokenDialogForAccessibility.rawValue])
         }
+        
+        self.player.currentItem?.select(options.first, in: group)
     }
 }


### PR DESCRIPTION
#### Ticket

[VIM-6350](https://vimean.atlassian.net/browse/VIM-6350)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- From the player interface, we want the user to be able to actually be able to activate captions on the video.

#### Implementation Summary

- Rename `describesMusicAndSound` to better describe that this is a flag for whether the text track is accessibility focused, rather than just providing subtitles.
- Add new `matches(_:)` method as an extension on `TextTrackMetadata`. This makes explicit that per the model server-side, there will only ever be one available text track with the same language and subtitle/caption status. Thus, for our purposes, these should be considered the "same". We don't really want to use `==` because that would overload the meaning: the underlying objects which conform to this protocol may not be equal themselves (indeed, they may not even be the same object), but `matches(_:)` confirms that they correspond to the same text track object on our video.
- Add a new `selectedTextTrack` property to `TextTrackCapable` and update the asynchronous method to take a callback which accepts both the list of available text tracks and the currently selected track.
- Rework selection logic a bit to use the new `matches(_:)` method for finding the `AVMediaSelectionOption` to select.
- Add `#available` checks for deprecated (iOS 11) `AVPlayerItem.selectedMediaOption(in:)` API, using `AVPlayerItem.currentMediaSelection.selectedMediaOption(in:)` where available.

#### Reviewer Tips

#### How to Test
