### PR TITLE
VIM-6695: Update nokogiri to v1.8.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'danger', '4.0.4'
 gem 'xcode-install', '2.1.0'
 gem 'xcpretty-json-formatter', '0.1.0'
 gem 'danger-xcode_summary', '0.1.0'
-gem 'nokogiri', '1.6.0'
+gem 'nokogiri', '1.8.5'
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval(File.read(plugins_path), binding) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_magick (4.5.1)
-    mini_portile (0.5.3)
+    mini_portile2 (2.3.0)
     minitest (5.11.3)
     molinillo (0.6.5)
     multi_json (1.13.1)
@@ -171,8 +171,8 @@ GEM
     nanaimo (0.2.5)
     nap (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
     octokit (4.9.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
@@ -235,7 +235,7 @@ DEPENDENCIES
   danger-xcode_summary (= 0.1.0)
   fastlane (= 2.42.0)
   fastlane-plugin-pretty_junit
-  nokogiri (= 1.6.0)
+  nokogiri (= 1.8.5)
   xcode-install (= 2.1.0)
   xcpretty-json-formatter (= 0.1.0)
 


### PR DESCRIPTION
#### Ticket

[VIM-6695](https://vimean.atlassian.net/browse/VIM-6695)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

Updates nokogiri to the latest version to address a security issue

#### Implementation Summary

- Bumping nokogiri to 1.8.5
