### PR TITLE
Updates Fastlane and CircleCI to build against Xcode 10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       BUNDLE_PATH: vendor/bundle
       FL_OUTPUT_DIR: output
     macos:
-      xcode: "10.0.0"
+      xcode: "10.1.0"
     working_directory: ~/PlayerKit
     shell: /bin/bash --login -o pipefail
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -17,7 +17,7 @@ default_platform :ios
 
 platform :ios do
   before_all do
-    ensure_xcode_version(version: "10.0")
+    ensure_xcode_version(version: "10.1")
   end
 
   desc "Run tests"


### PR DESCRIPTION
This PR updates both Fastlane and CircleCI to build and execute unit tests against Xcode 10.1.