### PR TITLE
Add ability to force faster start of AVPlayer

### DIFF
--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -145,6 +145,16 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     }
     
     // MARK: Setup
+
+    @available(iOS 10.0, *)
+    public var automaticallyWaitsToMinimizeStalling: Bool {
+        get {
+            return self.player.automaticallyWaitsToMinimizeStalling
+        }
+        set {
+            self.player.automaticallyWaitsToMinimizeStalling = newValue
+        }
+    }
     
     private func setupAirplay() {
         self.player.usesExternalPlaybackWhileExternalScreenIsActive = true


### PR DESCRIPTION
#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

PR is open to solve this issue: https://github.com/vimeo/PlayerKit/issues/42
I need an ability to start video playing ASAP even if would cause possible stalls.

#### Implementation Summary

I added a property which gives access to to `automaticallyWaitsToMinimizeStalling` property of underlying `AVPlayer`.

Closes issue #42 