### PR TITLE
Add method to manually set the player item on RegularPlayer

### DIFF
--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -33,18 +33,18 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     ///
     /// - Parameter asset: The AVAsset
     @objc open func set(_ asset: AVAsset) {
+        let playerItem = AVPlayerItem(asset: asset)
+        self.set(playerItem: playerItem)
+    }
+
+    @objc open func set(playerItem: AVPlayerItem) {
         // Prepare the old item for removal
-        
         if let currentItem = self.player.currentItem {
             self.removePlayerItemObservers(fromPlayerItem: currentItem)
         }
-        
+
         // Replace it with the new item
-        
-        let playerItem = AVPlayerItem(asset: asset)
-        
         self.addPlayerItemObservers(toPlayerItem: playerItem)
-        
         self.player.replaceCurrentItem(with: playerItem)
     }
     


### PR DESCRIPTION
#### Ticket

[VIM-7153](https://vimean.atlassian.net/browse/VIM-7153)

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Issue Summary

- We want to be able to provide a manually composed `AVPlayerItem` instead of just an asset.

#### Implementation Summary

- Introduce new method and use it in `set(_ asset:)`.

#### How to Test

- Should be tested as part of main PR.
