### PR TITLE
VIM-7178 & VIM-7179: Allow method overrides and add seek tolerance

### DIFF
--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -33,6 +33,7 @@ extension AVMediaSelectionOption: TextTrackMetadata {
         return self.regularPlayerView.playerLayer
     }
 
+    private var seekTolerance: CMTime?
     
     // MARK: Public API
     
@@ -111,8 +112,12 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     
     open func seek(to time: TimeInterval) {
         let cmTime = CMTimeMakeWithSeconds(time, preferredTimescale: Int32(NSEC_PER_SEC))
-        
-        self.player.seek(to: cmTime)
+
+        if let tolerance = self.seekTolerance {
+            self.player.seek(to: cmTime, toleranceBefore: tolerance, toleranceAfter: tolerance)
+        } else {
+            self.player.seek(to: cmTime)
+        }
         
         self.time = time
     }
@@ -129,6 +134,9 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     
     public init(seekTolerance: TimeInterval? = nil) {
         self.regularPlayerView = RegularPlayerView(frame: .zero)
+        self.seekTolerance = seekTolerance.map {
+            CMTimeMakeWithSeconds($0, preferredTimescale: Int32(NSEC_PER_SEC))
+        }
 
         super.init()
         

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -26,6 +26,13 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     // MARK: Private Properties
     
     fileprivate var player = AVPlayer()
+
+    private var regularPlayerView: RegularPlayerView
+
+    private var playerLayer: AVPlayerLayer {
+        return self.regularPlayerView.playerLayer
+    }
+
     
     // MARK: Public API
     
@@ -64,14 +71,8 @@ extension AVMediaSelectionOption: TextTrackMetadata {
         }
     }
     
-    public let view: UIView = RegularPlayerView(frame: .zero)
-    
-    private var regularPlayerView: RegularPlayerView {
-        return self.view as! RegularPlayerView
-    }
-    
-    private var playerLayer: AVPlayerLayer {
-        return self.regularPlayerView.playerLayer
+    open var view: UIView {
+        return regularPlayerView
     }
     
     // MARK: Player
@@ -108,7 +109,7 @@ extension AVMediaSelectionOption: TextTrackMetadata {
         return self.player.errorForPlayerOrItem
     }
     
-    public func seek(to time: TimeInterval) {
+    open func seek(to time: TimeInterval) {
         let cmTime = CMTimeMakeWithSeconds(time, preferredTimescale: Int32(NSEC_PER_SEC))
         
         self.player.seek(to: cmTime)
@@ -116,23 +117,23 @@ extension AVMediaSelectionOption: TextTrackMetadata {
         self.time = time
     }
     
-    public func play() {
+    open func play() {
         self.player.play()
     }
     
-    public func pause() {
+    open func pause() {
         self.player.pause()
     }
     
     // MARK: Lifecycle
     
-    public override init() {
+    public init(seekTolerance: TimeInterval? = nil) {
+        self.regularPlayerView = RegularPlayerView(frame: .zero)
+
         super.init()
         
         self.addPlayerObservers()
-        
         self.regularPlayerView.configureForPlayer(player: self.player)
-        
         self.setupAirplay()
     }
     
@@ -248,7 +249,7 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     }
     
     // MARK: Observation Helpers
-    
+
     private func playerItemStatusDidChange(status: AVPlayerItem.Status) {
         switch status {
         case .unknown:

--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -73,7 +73,7 @@ extension AVMediaSelectionOption: TextTrackMetadata {
     }
     
     open var view: UIView {
-        return regularPlayerView
+        return self.regularPlayerView
     }
     
     // MARK: Player


### PR DESCRIPTION
#### Ticket

[VIM-7178](https://vimean.atlassian.net/browse/VIM-7178)
[VIM-7179](https://vimean.atlassian.net/browse/VIM-7179)

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- Adds support for subclasses of `RegularPlayer`.

#### Implementation Summary

- Change `Player` functions to be `open` instead of `public`.
- Add `seekTolerance` parameter which, if set, is passed along to `AVPlayer.seek(to:toleranceBefore:toleranceAfter:)`.

#### How to Test

- Test as part of main Vimeo-iOS PR