### PR TITLE
VIM-XXXX: Smooth seeking

### DIFF
--- a/PlayerKit/Classes/RegularPlayer.swift
+++ b/PlayerKit/Classes/RegularPlayer.swift
@@ -190,7 +190,9 @@ extension AVMediaSelectionOption: TextTrackMetadata {
         assert(CMTIME_IS_VALID(self.seekTarget))
         let inProgressSeekTarget = self.seekTarget
 
-        let completion: (Bool) -> Void = { _ in
+        let completion: (Bool) -> Void = { [weak self] _ in
+            guard let self = self else { return }
+
             self.time = CMTimeGetSeconds(inProgressSeekTarget)
             if CMTimeCompare(inProgressSeekTarget, self.seekTarget) == 0 {
                 self.isSeekInProgress = false


### PR DESCRIPTION
#### Ticket

N/A

- *Note: this is required for Vimeo staff only. If not applicable to your PR, use "N/A".*

#### Pull Request Checklist

- [x] Resolved any merge conflicts
- [x] No build errors or warnings are introduced
- [x] New files are written in Swift
- [x] New classes contain license headers
- [x] New classes have Documentation
- [x] New public methods have Documentation

#### Issue Summary

- We follow the Apple Technical Q&A example to make seeking smoother.

#### Implementation Summary

- Track whether any seeks are currently in flight, and delay further calls to `seek(to:)` if so.

#### How to Test

- Test as part of main PR.